### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, only: [:edit]
-  before_action :product_info, only: [:show, :edit, :update]
+  before_action :product_info, only: [:show, :edit, :update, :destroy]
 
   def index
     @products = Product.all.includes(:user).order(id: :DESC)
@@ -34,6 +34,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @product.destroy
+    redirect_to root_path
+  end
+
   private
 
   def product_params
@@ -48,5 +53,4 @@ class ItemsController < ApplicationController
   def product_info
     @product = Product.find(params[:id])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, only: [:edit]
-  before_action :product_info, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
+  before_action :product_info, only: [:show, :update]
 
   def index
     @products = Product.all.includes(:user).order(id: :DESC)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @product.user_id %>
       <%= link_to '商品の編集', edit_item_path(@product), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@product), method: :delete, class:'item-destroy' %>
       <% else %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
登録した商品の情報を削除する機能。
# Why
出品者が登録した商品自体を削除したときに使用するため。

商品詳細ページから削除
https://gyazo.com/b71bc1e2ffd871b4e665506b2e7beeca